### PR TITLE
Fixed xkcd

### DIFF
--- a/content/xkcd.eval
+++ b/content/xkcd.eval
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 img_url=$(curl -sL https://c.xkcd.com/random/comic/ |
-          grep -o -e "https:\/\/imgs.xkcd.com\/comics\/[a-zA-Z0-9_.:\/]*")  
+          grep -o -e "https:\/\/imgs.xkcd.com\/comics\/[a-zA-Z0-9_.:\/]*.png")  
 
-curl -s "$img_url" > /tmp/xkcd
+curl -s `echo "${img_url}" | head -1` > /tmp/xkcd
 readlink -f "$(dirname "$0")/res/xkcd.html"


### PR DESCRIPTION
xkcd virkede ikke. Gætter på opdateringer til https://c.xkcd.com/random/comic/ har gjort så det tidligere regex samlede op flere elementer, nogen af dem var ikke engang png filer. Jeg har gjort så den kun fanger png filer og derfra vælger den første png fil.